### PR TITLE
Set book iframe width to readable size

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -1,0 +1,9 @@
+#book-display {
+  display: block;
+  margin: 0 auto;
+
+  width: 100%;
+  max-width: 60em;
+  height: calc(100vh - 80px);
+  border: 0;
+}

--- a/lib/alexandria.jsx
+++ b/lib/alexandria.jsx
@@ -210,7 +210,7 @@ const BookDisplayUI = ({id, title, canDownload, canEditMetadata}) => <div>
       </Nav>
     </Navbar.Collapse>
   </Navbar>
-  <iframe src={`/files/${id}/index.html`}/>
+  <iframe id="book-display" src={`/files/${id}/index.html`}/>
 </div>
 
 const BookDisplayContainer = (props, onData) => {


### PR DESCRIPTION
This sets the book width to be up to 60em, which is about the length of a readable line. It sets the height to be the height of the window. The height css does require a modern browser, so if that's a non-starter it may be possible to do some other way.
