### PR TITLE
Set sandstorm path when route changes

### DIFF
--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -38,6 +38,12 @@ const Home = composeWithTracker(HomeContainer)(HomeUI)
 
 if(Meteor.isClient)
   Meteor.startup(() => {
+    browserHistory.listen((location) => {
+      window.parent.postMessage({
+        setPath: location.pathname + location.hash
+      }, '*')
+    });
+
     ReactDOM.render(<Router history={browserHistory}>
       <Route path="/" component={Layout}>
         <IndexRoute component={Home}/>


### PR DESCRIPTION
This allows you to reload the sandstorm grain URL and return to the same book.
